### PR TITLE
add pkg_check argument to diffeq_setup() 

### DIFF
--- a/R/diffeqr.R
+++ b/R/diffeqr.R
@@ -3,6 +3,7 @@
 #' This function initializes Julia and the DifferentialEquations.jl package.
 #' The first time will be long since it includes precompilation.
 #'
+#' @param pkg.check logical, check for DifferentialEquations.jl package and install if necessary
 #' @param ... Parameters are passed down to JuliaCall::julia_setup
 #'
 #' @examples
@@ -14,9 +15,9 @@
 #' }
 #'
 #' @export
-diffeq_setup <- function (...){
+diffeq_setup <- function (pkg_check=FALSE, ...){
   julia <- JuliaCall::julia_setup(...)
-  JuliaCall::julia_install_package_if_needed("DifferentialEquations")
+  if(pkg_check) JuliaCall::julia_install_package_if_needed("DifferentialEquations")
   JuliaCall::julia_library("DifferentialEquations")
 }
 


### PR DESCRIPTION
The current Dev/CRAN versions of JuliaCall::julia_install_package_if_needed() / julia$installed_package("DifferentialEquations") seems to be corrupted. Thus, diffeqr_setup() is not properly executed on my local system. The additional pkg_check argument enables users to bypass this potential issue.
