### PR TITLE
fix: use `split=false` when jit-ing system, rely on defaults

### DIFF
--- a/R/diffeqr.R
+++ b/R/diffeqr.R
@@ -72,11 +72,8 @@ jitoptimize_ode <- function (de,prob){
   odesys = mtk$modelingtoolkitize(prob)
   
   JuliaCall::julia_assign("odesys", odesys)
-  jul_f = JuliaCall::julia_eval("jitf = ODEFunction(complete(odesys, split=false),jac=true)")
-  JuliaCall::julia_assign("u0", prob$u0)
-  JuliaCall::julia_assign("p", prob$p)
   JuliaCall::julia_assign("tspan", prob$tspan)
-  new_prob <- JuliaCall::julia_eval("ODEProblem(jitf, u0, tspan, p)")
+  new_prob <- JuliaCall::julia_eval("ODEProblem(complete(odesys, split=false), [], tspan; jac=true)")
 }
 
 #' Jit Optimize an SDEProblem
@@ -106,11 +103,8 @@ jitoptimize_sde <- function (de,prob){
 
   sdesys = mtk$modelingtoolkitize(prob)
   JuliaCall::julia_assign("sdesys", sdesys)
-  jul_f = JuliaCall::julia_eval("jitf = SDEFunction(complete(sdesys, split=false),jac=true)")
-  JuliaCall::julia_assign("u0", prob$u0)
-  JuliaCall::julia_assign("p", prob$p)
   JuliaCall::julia_assign("tspan", prob$tspan)
-  new_prob <- JuliaCall::julia_eval("SDEProblem(jitf, jitf.g, u0, tspan, p)")
+  new_prob <- JuliaCall::julia_eval("SDEProblem(complete(sdesys, split=false), [], tspan; jac=true)")
 }
 
 #' Setup DiffEqGPU

--- a/R/diffeqr.R
+++ b/R/diffeqr.R
@@ -70,10 +70,9 @@ jitoptimize_ode <- function (de,prob){
   mtk <- julia_pkg_import("ModelingToolkit",functions)
 
   odesys = mtk$modelingtoolkitize(prob)
-  odesys = mtk$complete(odesys)
   
   JuliaCall::julia_assign("odesys", odesys)
-  jul_f = JuliaCall::julia_eval("jitf = ODEFunction(odesys,jac=true)")
+  jul_f = JuliaCall::julia_eval("jitf = ODEFunction(complete(odesys, split=false),jac=true)")
   JuliaCall::julia_assign("u0", prob$u0)
   JuliaCall::julia_assign("p", prob$p)
   JuliaCall::julia_assign("tspan", prob$tspan)
@@ -106,9 +105,8 @@ jitoptimize_sde <- function (de,prob){
   mtk <- julia_pkg_import("ModelingToolkit",functions)
 
   sdesys = mtk$modelingtoolkitize(prob)
-  sdesys = mtk$complete(sdesys)
   JuliaCall::julia_assign("sdesys", sdesys)
-  jul_f = JuliaCall::julia_eval("jitf = SDEFunction(sdesys,jac=true)")
+  jul_f = JuliaCall::julia_eval("jitf = SDEFunction(complete(sdesys, split=false),jac=true)")
   JuliaCall::julia_assign("u0", prob$u0)
   JuliaCall::julia_assign("p", prob$p)
   JuliaCall::julia_assign("tspan", prob$tspan)


### PR DESCRIPTION
Following https://github.com/SciML/diffeqpy/pull/149

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
